### PR TITLE
don't `drawRemainder` when no whole weeks left

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -51,7 +51,9 @@ export function draw(dataModel, svg) {
 
   drawWeekScale(dataModel, guidesModel, svg);
   drawCurrentQuarter(dataModel, guidesModel, svg);
-  drawRemainder(dataModel, guidesModel, svg);
+  if (dataModel.currentQuarter.wholeWeeksLeft.durationInWeeks != 0) {
+    drawRemainder(dataModel, guidesModel, svg);
+  }
   drawDayHand(dataModel, guidesModel, svg);
   drawInfo(dataModel, guidesModel, svg);
   drawLogo(dataModel, guidesModel, svg);


### PR DESCRIPTION
- this avoids having a thin line show. this comes from drawing the zero area arc, but with border still stroked