### PR TITLE
disable generic console logging to Sentry

### DIFF
--- a/src/sentry.js
+++ b/src/sentry.js
@@ -5,7 +5,7 @@ import { CaptureConsole } from "@sentry/integrations";
 export function init({ tracesSampleRate }) {
   Sentry.init({
     dsn: "https://795e380a18ab416d997409fa24fa79b3@o1074871.ingest.sentry.io/6074817",
-    integrations: [new Integrations.BrowserTracing(), new CaptureConsole()],
+    integrations: [new Integrations.BrowserTracing()],
 
     tracesSampleRate,
   });


### PR DESCRIPTION
- it is too verbose