### PR TITLE
Cleanup tmp files: log only

### DIFF
--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -61,5 +61,6 @@ ARG RUST_LOG=info
 ENV RUST_LOG=$RUST_LOG
 ARG APP_URL=https://quarterly.houseofmoran.io/
 ENV APP_URL=$APP_URL
+ENV CLEANUP_MODE=watch
 
 ENTRYPOINT ["./server"]

--- a/preview/README.md
+++ b/preview/README.md
@@ -24,7 +24,11 @@ If you then go to `http://localhost:8080/screenshot.png` you should see a screen
 
 If you want to override the url fetched, you can set `APP_URL`:
 
-    APP_URL=https://example.com cargo run --bin server 
+    APP_URL=https://example.com cargo run --bin server
+
+If you want to get to delete tmp files that may be left around then you can define a `CLEANUP_MODE` which is either:
+* `watch`: just log out files it would delete
+* `delete`: actually delete them
 
 ## Running locally in Docker
 

--- a/preview/src/bin/server.rs
+++ b/preview/src/bin/server.rs
@@ -7,6 +7,16 @@ use tracing::{error, info, warn};
 use std::time::{Duration, SystemTime};
 use preview::cleanup;
 
+const TMP_MAX_AGE: Duration = Duration::from_secs(1 * 60);
+const TMP_DIR: &str = "/tmp";
+const TMP_PREFIX: &str = "rust-headless-chrome";
+
+#[derive(Clone, Copy, Debug)]
+enum CleanupMode {
+    Watch,
+    Delete,
+}
+
 #[derive(Clone, Debug)]
 struct AppState {
     url: String,
@@ -81,12 +91,8 @@ fn grab_screenshot(url: &str) -> Result<Png, Box<dyn std::error::Error>> {
     Ok(Png(png_data))
 }
 
-const TMP_MAX_AGE: Duration = Duration::from_secs(60);
-const TMP_DIR: &str = "/tmp";
-const PREFIX: &str = "rust-headless-chrome";
-
-async fn cleanup_tmp() {
-    info!("starting tmp cleanup");
+async fn cleanup_tmp(mode: CleanupMode) {
+    info!("starting tmp cleanup ({mode:?})");
 
     let now = SystemTime::now();
 
@@ -102,7 +108,7 @@ async fn cleanup_tmp() {
         info!("tmp file: {}, age: {:?}", f.file_name, f.age(now));
     }
 
-    let stale = match cleanup::old_files_with_prefix(files, PREFIX, TMP_MAX_AGE, now) {
+    let stale = match cleanup::old_files_with_prefix(files, TMP_PREFIX, TMP_MAX_AGE, now) {
         Ok(stale) => stale,
         Err(err) => {
             warn!("tmp cleanup: failed to filter stale files: {err}");
@@ -111,16 +117,23 @@ async fn cleanup_tmp() {
     };
 
     if stale.is_empty() {
-        info!("tmp cleanup: no stale files to delete");
+        info!("tmp cleanup: no stale files matched criteria");
     }
-    else {
-        info!("tmp cleanup: {} stale files to delete", stale.len());
 
-        let results = cleanup::delete_files(stale).await;
-        for (path, outcome) in results {
-            match outcome {
-                Ok(()) => info!("tmp cleanup: deleted {:?}", path),
-                Err(err) => warn!("tmp cleanup: failed to delete {:?}: {err}", path),
+    match mode {
+        CleanupMode::Watch => {
+            for file in stale {
+                info!("tmp cleanup (watch): would delete {:?}", file.path);
+            }
+        }
+        CleanupMode::Delete => {
+            info!("tmp cleanup: deleting {} stale files", stale.len());
+            let results = cleanup::delete_files(stale).await;
+            for (path, outcome) in results {
+                match outcome {
+                    Ok(()) => info!("tmp cleanup: deleted {:?}", path),
+                    Err(err) => warn!("tmp cleanup: failed to delete {:?}: {err}", path),
+                }
             }
         }
     }
@@ -137,17 +150,22 @@ async fn main() -> std::io::Result<()> {
     tracing_subscriber::fmt::init();
     info!("logging setup completed");
 
-    if std::env::var("CLEANUP_TMP").as_deref() == Ok("true") {
-        info!("starting tmp cleanup task");
-        tokio::spawn(async {
+    let cleanup_mode = match std::env::var("CLEANUP_MODE").ok().as_deref() {
+        Some("watch") => Some(CleanupMode::Watch),
+        Some("delete") => Some(CleanupMode::Delete),
+        _ => None,
+    };
+
+    if let Some(mode) = cleanup_mode {
+        info!("starting tmp cleanup task in {:?} mode", mode);
+        tokio::spawn(async move {
             let mut interval = tokio::time::interval(TMP_MAX_AGE);
             loop {
                 interval.tick().await;
-                cleanup_tmp().await;
+                cleanup_tmp(mode).await;
             }
         });
-    }
-    else {
+    } else {
         info!("tmp cleanup task disabled");
     }
 

--- a/preview/src/bin/server.rs
+++ b/preview/src/bin/server.rs
@@ -3,19 +3,9 @@ use bytes::Bytes;
 use headless_chrome::{Browser, LaunchOptionsBuilder};
 use tower_http::{trace::TraceLayer};
 use tower::ServiceBuilder;
-use tracing::{error, info, warn};
-use std::time::{Duration, SystemTime};
+use tracing::{error, info};
+use std::time::Duration;
 use preview::cleanup;
-
-const TMP_MAX_AGE: Duration = Duration::from_secs(1 * 60);
-const TMP_DIR: &str = "/tmp";
-const TMP_PREFIX: &str = "rust-headless-chrome";
-
-#[derive(Clone, Copy, Debug)]
-enum CleanupMode {
-    Watch,
-    Delete,
-}
 
 #[derive(Clone, Debug)]
 struct AppState {
@@ -91,57 +81,6 @@ fn grab_screenshot(url: &str) -> Result<Png, Box<dyn std::error::Error>> {
     Ok(Png(png_data))
 }
 
-async fn cleanup_tmp(mode: CleanupMode) {
-    info!("starting tmp cleanup ({mode:?})");
-
-    let now = SystemTime::now();
-
-    let files = match cleanup::list_files(TMP_DIR).await {
-        Ok(files) => files,
-        Err(err) => {
-            warn!("tmp cleanup: failed to list files: {err}");
-            return;
-        }
-    };
-
-    for f in &files {
-        info!("tmp file: {}, used age: {:?}", f.file_name, f.used_age(now));
-    }
-
-    let stale = match cleanup::old_files_with_prefix(files, TMP_PREFIX, TMP_MAX_AGE, now) {
-        Ok(stale) => stale,
-        Err(err) => {
-            warn!("tmp cleanup: failed to filter stale files: {err}");
-            return;
-        }
-    };
-
-    if stale.is_empty() {
-        info!("tmp cleanup: no stale files matched criteria");
-    }
-
-    match mode {
-        CleanupMode::Watch => {
-            for file in stale {
-                info!("tmp cleanup (watch): would delete {:?}", file.path);
-            }
-        }
-        CleanupMode::Delete => {
-            info!("tmp cleanup: deleting {} stale files", stale.len());
-            let results = cleanup::delete_files(stale).await;
-            for (path, outcome) in results {
-                match outcome {
-                    Ok(()) => info!("tmp cleanup: deleted {:?}", path),
-                    Err(err) => warn!("tmp cleanup: failed to delete {:?}: {err}", path),
-                }
-            }
-        }
-    }
-
-    info!("tmp cleanup completed");
-}
-
-
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_BACKTRACE", "1");
@@ -151,18 +90,18 @@ async fn main() -> std::io::Result<()> {
     info!("logging setup completed");
 
     let cleanup_mode = match std::env::var("CLEANUP_MODE").ok().as_deref() {
-        Some("watch") => Some(CleanupMode::Watch),
-        Some("delete") => Some(CleanupMode::Delete),
+        Some("watch") => Some(cleanup::CleanupMode::Watch),
+        Some("delete") => Some(cleanup::CleanupMode::Delete),
         _ => None,
     };
 
     if let Some(mode) = cleanup_mode {
         info!("starting tmp cleanup task in {:?} mode", mode);
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(TMP_MAX_AGE);
+            let mut interval = tokio::time::interval(cleanup::TMP_MAX_AGE);
             loop {
                 interval.tick().await;
-                cleanup_tmp(mode).await;
+                cleanup::cleanup_tmp(mode).await;
             }
         });
     } else {

--- a/preview/src/bin/server.rs
+++ b/preview/src/bin/server.rs
@@ -105,7 +105,7 @@ async fn cleanup_tmp(mode: CleanupMode) {
     };
 
     for f in &files {
-        info!("tmp file: {}, age: {:?}", f.file_name, f.age(now));
+        info!("tmp file: {}, used age: {:?}", f.file_name, f.used_age(now));
     }
 
     let stale = match cleanup::old_files_with_prefix(files, TMP_PREFIX, TMP_MAX_AGE, now) {

--- a/preview/src/bin/server.rs
+++ b/preview/src/bin/server.rs
@@ -3,8 +3,9 @@ use bytes::Bytes;
 use headless_chrome::{Browser, LaunchOptionsBuilder};
 use tower_http::{trace::TraceLayer};
 use tower::ServiceBuilder;
-use tracing::{error, info};
-use std::time::Duration;
+use tracing::{error, info, warn};
+use std::time::{Duration, SystemTime};
+use preview::cleanup;
 
 #[derive(Clone, Debug)]
 struct AppState {
@@ -80,6 +81,53 @@ fn grab_screenshot(url: &str) -> Result<Png, Box<dyn std::error::Error>> {
     Ok(Png(png_data))
 }
 
+const TMP_MAX_AGE: Duration = Duration::from_secs(60);
+const TMP_DIR: &str = "/tmp";
+const PREFIX: &str = "rust-headless-chrome";
+
+async fn cleanup_tmp() {
+    info!("starting tmp cleanup");
+
+    let now = SystemTime::now();
+
+    let files = match cleanup::list_files(TMP_DIR).await {
+        Ok(files) => files,
+        Err(err) => {
+            warn!("tmp cleanup: failed to list files: {err}");
+            return;
+        }
+    };
+
+    for f in &files {
+        info!("tmp file: {}, age: {:?}", f.file_name, f.age(now));
+    }
+
+    let stale = match cleanup::old_files_with_prefix(files, PREFIX, TMP_MAX_AGE, now) {
+        Ok(stale) => stale,
+        Err(err) => {
+            warn!("tmp cleanup: failed to filter stale files: {err}");
+            return;
+        }
+    };
+
+    if stale.is_empty() {
+        info!("tmp cleanup: no stale files to delete");
+    }
+    else {
+        info!("tmp cleanup: {} stale files to delete", stale.len());
+
+        let results = cleanup::delete_files(stale).await;
+        for (path, outcome) in results {
+            match outcome {
+                Ok(()) => info!("tmp cleanup: deleted {:?}", path),
+                Err(err) => warn!("tmp cleanup: failed to delete {:?}: {err}", path),
+            }
+        }
+    }
+
+    info!("tmp cleanup completed");
+}
+
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
@@ -88,6 +136,20 @@ async fn main() -> std::io::Result<()> {
     println!("setting up logging, next message should be from log (if log-level set to INFO)");
     tracing_subscriber::fmt::init();
     info!("logging setup completed");
+
+    if std::env::var("CLEANUP_TMP").as_deref() == Ok("true") {
+        info!("starting tmp cleanup task");
+        tokio::spawn(async {
+            let mut interval = tokio::time::interval(TMP_MAX_AGE);
+            loop {
+                interval.tick().await;
+                cleanup_tmp().await;
+            }
+        });
+    }
+    else {
+        info!("tmp cleanup task disabled");
+    }
 
     let state = AppState::from_env();
     info!("Using state: {:?}", state);

--- a/preview/src/cleanup.rs
+++ b/preview/src/cleanup.rs
@@ -9,11 +9,11 @@ use tokio::io;
 pub struct FileCandidate {
     pub path: PathBuf,
     pub file_name: String,
-    pub last_touched: SystemTime,
+    pub last_used: SystemTime,
 }
 
 impl FileCandidate {
-    pub fn new(path: impl Into<PathBuf>, last_touched: SystemTime) -> io::Result<Self> {
+    pub fn new(path: impl Into<PathBuf>, last_used: SystemTime) -> io::Result<Self> {
         let path: PathBuf = path.into();
         let file_name = path
             .file_name()
@@ -23,16 +23,16 @@ impl FileCandidate {
         Ok(Self {
             path,
             file_name,
-            last_touched,
+            last_used,
         })
     }
 
-    pub fn age(&self, now: SystemTime) -> Result<Duration, Box<dyn Error + Send + Sync>> {
-        Ok(now.duration_since(self.last_touched)?)
+    pub fn used_age(&self, now: SystemTime) -> Result<Duration, Box<dyn Error + Send + Sync>> {
+        Ok(now.duration_since(self.last_used)?)
     }
 }
 
-/// List files in the given directory, capturing the newest of created/last-accessed timestamps as `last_touched`.
+/// List files in the given directory, capturing the newest of created/last-accessed timestamps as `last_used`.
 pub async fn list_files(dir: impl AsRef<Path>) -> io::Result<Vec<FileCandidate>> {
     let mut entries = fs::read_dir(dir).await?;
     let mut files = Vec::new();
@@ -42,17 +42,18 @@ pub async fn list_files(dir: impl AsRef<Path>) -> io::Result<Vec<FileCandidate>>
             let metadata = entry.metadata().await?;
 
             let created = metadata.created()?;
+            let modified = metadata.modified()?;
             let accessed = metadata.accessed()?;
-            let last_touched = created.max(accessed);
+            let last_used = created.max(modified).max(accessed);
 
-            files.push(FileCandidate::new(entry.path(), last_touched)?);
+            files.push(FileCandidate::new(entry.path(), last_used)?);
         }
     }
 
     Ok(files)
 }
 
-/// Keep only files whose names start with `prefix` and whose `age` is more than `max_age`
+/// Keep only files whose names start with `prefix` and whose `used_age` is more than `max_age`
 /// relative to `now`.
 pub fn old_files_with_prefix(
     files: Vec<FileCandidate>,
@@ -64,7 +65,7 @@ pub fn old_files_with_prefix(
 
     for file in files {
         if file.file_name.starts_with(prefix) {
-            let age = file.age(now)?;
+            let age = file.used_age(now)?;
             if age > max_age {
                 matched.push(file);
             }
@@ -135,24 +136,5 @@ mod tests {
             .collect();
 
         assert_eq!(names, vec!["file_old"]);
-    }
-
-    #[test]
-    fn older_than_respects_now() {
-        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
-        let duration = Duration::from_secs(300);
-
-        let old = now - Duration::from_secs(400);
-        let recent = now - Duration::from_secs(100);
-        let future = now + Duration::from_secs(100);
-
-        let old_file = FileCandidate::new("old", old).unwrap();
-        let recent_file = FileCandidate::new("recent", recent).unwrap();
-        let future_file = FileCandidate::new("future", future).unwrap();
-
-        assert!(old_file.age(now).map(|age| age >= duration).unwrap());
-        assert!(!recent_file.age(now).map(|age| age >= duration).unwrap());
-        // Future timestamps should propagate an error rather than be treated as stale.
-        assert!(future_file.age(now).is_err());
     }
 }

--- a/preview/src/cleanup.rs
+++ b/preview/src/cleanup.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
@@ -5,74 +6,76 @@ use tokio::fs;
 use tokio::io;
 
 #[derive(Debug, Clone)]
-pub struct TmpFileInfo {
+pub struct FileCandidate {
     pub path: PathBuf,
-    pub created: Option<SystemTime>,
-    pub accessed: Option<SystemTime>,
+    pub file_name: String,
+    pub last_touched: SystemTime,
 }
 
-/// List files in `tmp_dir`, capturing their created and last accessed times when available.
-pub async fn list_tmp_files(tmp_dir: impl AsRef<Path>) -> io::Result<Vec<TmpFileInfo>> {
-    let mut entries = fs::read_dir(tmp_dir).await?;
-    let mut files = Vec::new();
+impl FileCandidate {
+    pub fn new(path: impl Into<PathBuf>, last_touched: SystemTime) -> io::Result<Self> {
+        let path: PathBuf = path.into();
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid file name"))?
+            .to_string_lossy()
+            .into_owned();
+        Ok(Self {
+            path,
+            file_name,
+            last_touched,
+        })
+    }
 
+    pub fn age(&self, now: SystemTime) -> Result<Duration, Box<dyn Error + Send + Sync>> {
+        Ok(now.duration_since(self.last_touched)?)
+    }
+}
+
+/// List files in the given directory, capturing the newest of created/last-accessed timestamps as `last_touched`.
+pub async fn list_files(dir: impl AsRef<Path>) -> io::Result<Vec<FileCandidate>> {
+    let mut entries = fs::read_dir(dir).await?;
+    let mut files = Vec::new();
     while let Some(entry) = entries.next_entry().await? {
         let file_type = entry.file_type().await?;
-        if !file_type.is_file() {
-            continue;
+        if file_type.is_file() {
+            let metadata = entry.metadata().await?;
+
+            let created = metadata.created()?;
+            let accessed = metadata.accessed()?;
+            let last_touched = created.max(accessed);
+
+            files.push(FileCandidate::new(entry.path(), last_touched)?);
         }
-
-        let metadata = entry.metadata().await?;
-
-        files.push(TmpFileInfo {
-            path: entry.path(),
-            created: metadata.created().ok(),
-            accessed: metadata.accessed().ok(),
-        });
     }
 
     Ok(files)
 }
 
-/// Keep only files whose names start with `prefix` and have not been created or accessed
-/// within the last `stale_for` duration.
-pub fn stale_files_with_prefix(
-    files: Vec<TmpFileInfo>,
+/// Keep only files whose names start with `prefix` and whose `age` is more than `max_age`
+/// relative to `now`.
+pub fn old_files_with_prefix(
+    files: Vec<FileCandidate>,
     prefix: &str,
-    stale_for: Duration,
-) -> Vec<TmpFileInfo> {
-    files
-        .into_iter()
-        .filter(|file| {
-            let name = match file.path.file_name().and_then(|name| name.to_str()) {
-                Some(name) => name,
-                None => return false,
-            };
+    max_age: Duration,
+    now: SystemTime,
+) -> Result<Vec<FileCandidate>, Box<dyn Error + Send + Sync>> {
+    let mut matched = Vec::new();
 
-            if !name.starts_with(prefix) {
-                return false;
+    for file in files {
+        if file.file_name.starts_with(prefix) {
+            let age = file.age(now)?;
+            if age > max_age {
+                matched.push(file);
             }
+        }
+    }
 
-            let created_stale = file
-                .created
-                .map(|time| older_than(time, stale_for))
-                .unwrap_or(false);
-            let accessed_stale = file
-                .accessed
-                .map(|time| older_than(time, stale_for))
-                .unwrap_or(false);
-
-            created_stale && accessed_stale
-        })
-        .collect()
-}
-
-fn older_than(time: SystemTime, duration: Duration) -> bool {
-    matches!(SystemTime::now().duration_since(time), Ok(elapsed) if elapsed >= duration)
+    Ok(matched)
 }
 
 /// Attempt to delete each file; returns the per-file result so callers can log failures.
-pub async fn delete_files(files: Vec<TmpFileInfo>) -> Vec<(PathBuf, io::Result<()>)> {
+pub async fn delete_files(files: Vec<FileCandidate>) -> Vec<(PathBuf, io::Result<()>)> {
     let mut results = Vec::new();
 
     for file in files {
@@ -82,4 +85,74 @@ pub async fn delete_files(files: Vec<TmpFileInfo>) -> Vec<(PathBuf, io::Result<(
     }
 
     results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixed_now() -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000)
+    }
+
+    #[test]
+    fn filters_by_prefix() {
+        let now = fixed_now();
+        let max_age = Duration::from_secs(300);
+        let old = now - Duration::from_secs(301);
+
+        let files = vec![
+            FileCandidate::new("drop_alpha1", old).unwrap(),
+            FileCandidate::new("keep_beta", old).unwrap(),
+            FileCandidate::new("drop_alpha2", old).unwrap(),
+        ];
+
+        let stale = old_files_with_prefix(files, "drop_", max_age, now).unwrap();
+        let names: Vec<_> = stale
+            .into_iter()
+            .map(|f| f.file_name)
+            .collect();
+
+        assert_eq!(names, vec!["drop_alpha1", "drop_alpha2"]);
+    }
+
+    #[test]
+    fn filters_by_staleness() {
+        let now = fixed_now();
+        let max_age = Duration::from_secs(300);
+        let old = now - Duration::from_secs(301);
+        let recent = now - Duration::from_secs(60);
+
+        let files = vec![
+            FileCandidate::new("file_old", old).unwrap(),
+            FileCandidate::new("file_recent", recent).unwrap(),
+        ];
+
+        let stale = old_files_with_prefix(files, "file", max_age, now).unwrap();
+        let names: Vec<_> = stale
+            .into_iter()
+            .map(|f| f.file_name)
+            .collect();
+
+        assert_eq!(names, vec!["file_old"]);
+    }
+
+    #[test]
+    fn older_than_respects_now() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        let duration = Duration::from_secs(300);
+
+        let old = now - Duration::from_secs(400);
+        let recent = now - Duration::from_secs(100);
+        let future = now + Duration::from_secs(100);
+
+        let old_file = FileCandidate::new("old", old).unwrap();
+        let recent_file = FileCandidate::new("recent", recent).unwrap();
+        let future_file = FileCandidate::new("future", future).unwrap();
+
+        assert!(old_file.age(now).map(|age| age >= duration).unwrap());
+        assert!(!recent_file.age(now).map(|age| age >= duration).unwrap());
+        // Future timestamps should propagate an error rather than be treated as stale.
+        assert!(future_file.age(now).is_err());
+    }
 }

--- a/preview/src/cleanup.rs
+++ b/preview/src/cleanup.rs
@@ -1,0 +1,85 @@
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use tokio::fs;
+use tokio::io;
+
+#[derive(Debug, Clone)]
+pub struct TmpFileInfo {
+    pub path: PathBuf,
+    pub created: Option<SystemTime>,
+    pub accessed: Option<SystemTime>,
+}
+
+/// List files in `tmp_dir`, capturing their created and last accessed times when available.
+pub async fn list_tmp_files(tmp_dir: impl AsRef<Path>) -> io::Result<Vec<TmpFileInfo>> {
+    let mut entries = fs::read_dir(tmp_dir).await?;
+    let mut files = Vec::new();
+
+    while let Some(entry) = entries.next_entry().await? {
+        let file_type = entry.file_type().await?;
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let metadata = entry.metadata().await?;
+
+        files.push(TmpFileInfo {
+            path: entry.path(),
+            created: metadata.created().ok(),
+            accessed: metadata.accessed().ok(),
+        });
+    }
+
+    Ok(files)
+}
+
+/// Keep only files whose names start with `prefix` and have not been created or accessed
+/// within the last `stale_for` duration.
+pub fn stale_files_with_prefix(
+    files: Vec<TmpFileInfo>,
+    prefix: &str,
+    stale_for: Duration,
+) -> Vec<TmpFileInfo> {
+    files
+        .into_iter()
+        .filter(|file| {
+            let name = match file.path.file_name().and_then(|name| name.to_str()) {
+                Some(name) => name,
+                None => return false,
+            };
+
+            if !name.starts_with(prefix) {
+                return false;
+            }
+
+            let created_stale = file
+                .created
+                .map(|time| older_than(time, stale_for))
+                .unwrap_or(false);
+            let accessed_stale = file
+                .accessed
+                .map(|time| older_than(time, stale_for))
+                .unwrap_or(false);
+
+            created_stale && accessed_stale
+        })
+        .collect()
+}
+
+fn older_than(time: SystemTime, duration: Duration) -> bool {
+    matches!(SystemTime::now().duration_since(time), Ok(elapsed) if elapsed >= duration)
+}
+
+/// Attempt to delete each file; returns the per-file result so callers can log failures.
+pub async fn delete_files(files: Vec<TmpFileInfo>) -> Vec<(PathBuf, io::Result<()>)> {
+    let mut results = Vec::new();
+
+    for file in files {
+        let path = file.path.clone();
+        let outcome = fs::remove_file(&path).await;
+        results.push((path, outcome));
+    }
+
+    results
+}

--- a/preview/src/cleanup.rs
+++ b/preview/src/cleanup.rs
@@ -2,8 +2,70 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
+use tracing::{info, warn};
+
 use tokio::fs;
 use tokio::io;
+
+pub const TMP_MAX_AGE: Duration = Duration::from_secs(60);
+const TMP_DIR: &str = "/tmp";
+const TMP_PREFIX: &str = "rust-headless-chrome";
+
+#[derive(Clone, Copy, Debug)]
+pub enum CleanupMode {
+    Watch,
+    Delete,
+}
+
+pub async fn cleanup_tmp(mode: CleanupMode) {
+    info!("starting tmp cleanup ({mode:?})");
+
+    let now = SystemTime::now();
+
+    let files = match list_files(TMP_DIR).await {
+        Ok(files) => files,
+        Err(err) => {
+            warn!("tmp cleanup: failed to list files: {err}");
+            return;
+        }
+    };
+
+    for f in &files {
+        info!("tmp file: {}, used age: {:?}", f.file_name, f.used_age(now));
+    }
+
+    let stale = match old_files_with_prefix(files, TMP_PREFIX, TMP_MAX_AGE, now) {
+        Ok(stale) => stale,
+        Err(err) => {
+            warn!("tmp cleanup: failed to filter stale files: {err}");
+            return;
+        }
+    };
+
+    if stale.is_empty() {
+        info!("tmp cleanup: no stale files matched criteria");
+    }
+
+    match mode {
+        CleanupMode::Watch => {
+            for file in stale {
+                info!("tmp cleanup (watch): would delete {:?}", file.path);
+            }
+        }
+        CleanupMode::Delete => {
+            info!("tmp cleanup: deleting {} stale files", stale.len());
+            let results = delete_files(stale).await;
+            for (path, outcome) in results {
+                match outcome {
+                    Ok(()) => info!("tmp cleanup: deleted {:?}", path),
+                    Err(err) => warn!("tmp cleanup: failed to delete {:?}: {err}", path),
+                }
+            }
+        }
+    }
+
+    info!("tmp cleanup completed");
+}
 
 #[derive(Debug, Clone)]
 pub struct FileCandidate {

--- a/preview/src/lib.rs
+++ b/preview/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod grab;
+pub mod cleanup;


### PR DESCRIPTION
This is a partial attempt at fixing issue #59 : this implements a `watch` on any files in `/tmp` which begin with `rust-headless-chrome`. Before I delete them, I want to see when they appear.